### PR TITLE
feat: parse frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,23 @@ Emitted when the user modifies the raw markdown content in the editor. The event
 > [!NOTE]
 > The `update:modelValue` event is debounced as the user is typing.
 
+#### `update:frontmatter`
+
+Emitted when the user modifies the raw markdown content in the editor and the internal frontmatter, if present, changes. The event contains a payload `Record<string, any>` of the document's YAML frontmatter.
+
+> [!NOTE]
+> The `update:frontmatter` event is debounced as the user is typing.
+
 #### `save`
 
-Emitted whenever the user triggers the `save` toolbar action. The event contains a payload `string` of the raw markdown content.
+Emitted whenever the user triggers the `save` toolbar action. The event emits a payload with the following interface:
+
+```typescript
+interface EmitUpdatePayload {
+  content: string
+  frontmatter: Frontmatter | undefined
+}
+```
 
 #### `cancel`
 

--- a/package.json
+++ b/package.json
@@ -54,8 +54,10 @@
   },
   "dependencies": {
     "@kong/icons": "^1.8.14",
+    "@mdit-vue/plugin-frontmatter": "^2.0.0",
     "@sindresorhus/slugify": "^2.2.1",
     "@vueuse/core": "^10.7.1",
+    "buffer": "^6.0.3",
     "html-format": "^1.1.6",
     "markdown-it": "^14.0.0",
     "markdown-it-abbr": "^2.0.0",
@@ -80,6 +82,7 @@
     "@digitalroute/cz-conventional-changelog-for-jira": "^8.0.1",
     "@evilmartians/lefthook": "^1.5.6",
     "@kong/design-tokens": "^1.12.7",
+    "@mdit-vue/types": "^2.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@shikijs/markdown-it": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ dependencies:
   '@kong/icons':
     specifier: ^1.8.14
     version: 1.8.14(vue@3.4.14)
+  '@mdit-vue/plugin-frontmatter':
+    specifier: ^2.0.0
+    version: 2.0.0
   '@sindresorhus/slugify':
     specifier: ^2.2.1
     version: 2.2.1
   '@vueuse/core':
     specifier: ^10.7.1
     version: 10.7.1(vue@3.4.14)
+  buffer:
+    specifier: ^6.0.3
+    version: 6.0.3
   html-format:
     specifier: ^1.1.6
     version: 1.1.6
@@ -82,6 +88,9 @@ devDependencies:
   '@kong/design-tokens':
     specifier: ^1.12.7
     version: 1.12.7
+  '@mdit-vue/types':
+    specifier: ^2.0.0
+    version: 2.0.0
   '@semantic-release/changelog':
     specifier: ^6.0.3
     version: 6.0.3(semantic-release@22.0.12)
@@ -1171,6 +1180,18 @@ packages:
     dependencies:
       vue: 3.4.14(typescript@5.3.3)
     dev: false
+
+  /@mdit-vue/plugin-frontmatter@2.0.0:
+    resolution: {integrity: sha512-/LrT6E60QI4XV4mqx3J87hqYXlR7ZyMvndmftR2RGz7cRAwa/xL+kyFLlgrMxkBIKitOShKa3LS/9Ov9b0fU+g==}
+    dependencies:
+      '@mdit-vue/types': 2.0.0
+      '@types/markdown-it': 13.0.7
+      gray-matter: 4.0.3
+      markdown-it: 14.0.0
+    dev: false
+
+  /@mdit-vue/types@2.0.0:
+    resolution: {integrity: sha512-1BeEB+DbtmDMUAfvbNUj5Hso8cSl2sBVK2iTyOMAqhfDVLdh+/9+D0JmQHaCeUk/vuJoMhOwbweZvh55wHxm4w==}
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2381,6 +2402,12 @@ packages:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: true
 
+  /argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+    dependencies:
+      sprintf-js: 1.0.3
+    dev: false
+
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2513,7 +2540,6 @@ packages:
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: true
 
   /before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
@@ -2601,6 +2627,13 @@ packages:
       base64-js: 1.5.1
       ieee754: 1.2.1
     dev: true
+
+  /buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -4049,7 +4082,6 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /esquery@1.5.0:
     resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
@@ -4120,6 +4152,13 @@ packages:
     dependencies:
       homedir-polyfill: 1.0.3
     dev: true
+
+  /extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-extendable: 0.1.1
+    dev: false
 
   /external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -4591,6 +4630,16 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+    dependencies:
+      js-yaml: 3.14.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+    dev: false
+
   /handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -4770,7 +4819,6 @@ packages:
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: true
 
   /ignore@5.3.0:
     resolution: {integrity: sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==}
@@ -4979,6 +5027,11 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
     dev: true
+
+  /is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -5226,6 +5279,14 @@ packages:
     resolution: {integrity: sha512-Olnt+V7xYdvGze9YTbGFZIfQXuGV4R3nQwwl8BrtgaPE/wq8UFpUHWuTNc05saowhSr1ZO6tx+V6RjE9D5YQog==}
     dev: true
 
+  /js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: false
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -5347,7 +5408,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -7054,6 +7114,14 @@ packages:
       xmlchars: 2.2.0
     dev: true
 
+  /section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+    dev: false
+
   /semantic-release@22.0.12(typescript@5.3.3):
     resolution: {integrity: sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==}
     engines: {node: ^18.17 || >=20.6.1}
@@ -7287,6 +7355,10 @@ packages:
     engines: {node: '>= 10.x'}
     dev: true
 
+  /sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+    dev: false
+
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
@@ -7370,6 +7442,11 @@ packages:
     dependencies:
       ansi-regex: 6.0.1
     dev: true
+
+  /strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}

--- a/sandbox/App.vue
+++ b/sandbox/App.vue
@@ -20,7 +20,7 @@
       </p>
       <hr>
       <MarkdownUi
-        v-model="content"
+        v-model="editorContent"
         downloadable
         editable
         filename="example-document"
@@ -28,6 +28,7 @@
         @cancel="cancelEdit"
         @mode="modeChanged"
         @save="contentSaved"
+        @update:frontmatter="frontmatterUpdated"
         @update:model-value="contentUpdated"
       />
     </main>
@@ -45,27 +46,31 @@ const preferredColorScheme = usePreferredColorScheme()
 const activeTheme = computed(() => preferredColorScheme.value === 'dark' ? preferredColorScheme.value : 'light')
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const contentUpdated = (markdown: string) => {
+const contentUpdated = (content: string) => {
   console.log('content updated')
+}
+
+const frontmatterUpdated = (frontmatter: Record<string, any> | undefined) => {
+  console.log('frontmatter updated', frontmatter)
 }
 
 const mode = ref<string>('read')
 const modeChanged = (m: string) => {
   mode.value = m
   if (mode.value === 'edit' || mode.value === 'split') {
-    originalContent.value = content.value
+    originalContent.value = editorContent.value
     console.log('begin editing')
   }
 }
 
 const cancelEdit = () => {
-  content.value = originalContent.value
+  editorContent.value = originalContent.value
   console.log('canceled')
 }
 
-const contentSaved = (markdown: string) => {
-  originalContent.value = content.value
-  console.log('saved! %o', markdown)
+const contentSaved = ({ content, frontmatter }: any) => {
+  originalContent.value = editorContent.value
+  console.log('saved! %o', content, frontmatter)
 }
 
 const mockMarkdownResponse = async (): Promise<Record<string, any>> => {
@@ -75,7 +80,7 @@ const mockMarkdownResponse = async (): Promise<Record<string, any>> => {
 }
 
 const originalContent = ref<string>('')
-const content = ref<string>('')
+const editorContent = ref<string>('')
 
 onBeforeMount(async () => {
   // Simulate fetching the document
@@ -84,7 +89,7 @@ onBeforeMount(async () => {
   // Store the original content in case the user cancels
   originalContent.value = markdownContent
   // Copy the content for editing
-  content.value = originalContent.value
+  editorContent.value = originalContent.value
 })
 </script>
 

--- a/src/composables/useMarkdownIt.ts
+++ b/src/composables/useMarkdownIt.ts
@@ -30,7 +30,7 @@ export default function useMarkdownIt() {
   const init = async (theme: Theme = 'light'): Promise<void> => {
     const { MarkdownItShiki } = useShiki()
 
-    // @ts-ignore
+    // @ts-ignore - Polyfill for Buffer in the browser environment
     window.Buffer = Buffer
 
     md.value = MarkdownIt({

--- a/src/composables/useMarkdownIt.ts
+++ b/src/composables/useMarkdownIt.ts
@@ -9,6 +9,7 @@ import abbreviation from 'markdown-it-abbr'
 import anchor from 'markdown-it-anchor'
 import attrs from 'markdown-it-attrs'
 import deflist from 'markdown-it-deflist'
+import { frontmatterPlugin } from '@mdit-vue/plugin-frontmatter'
 // @ts-ignore - export does exist
 import { full as emoji } from 'markdown-it-emoji'
 import footnote from 'markdown-it-footnote'
@@ -19,6 +20,7 @@ import superscript from 'markdown-it-sup'
 import tasklists from 'markdown-it-task-lists'
 import markdownItTextualUml from 'markdown-it-textual-uml'
 import slugify from '@sindresorhus/slugify'
+import { Buffer } from 'buffer'
 
 // MarkdownIt instance
 const md = ref()
@@ -27,6 +29,9 @@ export default function useMarkdownIt() {
   /** Initialize markdown-it - ideally called in the `onBeforeMount` hook */
   const init = async (theme: Theme = 'light'): Promise<void> => {
     const { MarkdownItShiki } = useShiki()
+
+    // @ts-ignore
+    window.Buffer = Buffer
 
     md.value = MarkdownIt({
       html: false, // Keep disabled to prevent XSS
@@ -65,6 +70,13 @@ export default function useMarkdownIt() {
       .use(tasklists, {
         label: true,
         enabled: false, // Not enabled since checking the box doesn't update the markdown
+      })
+      .use(frontmatterPlugin, {
+        // options
+        grayMatterOptions: {
+          language: 'yaml',
+        },
+        renderExcerpt: false,
       })
 
     // disable converting email to link

--- a/src/types/markdown-ui.ts
+++ b/src/types/markdown-ui.ts
@@ -1,5 +1,6 @@
 // Get a generic `@kong/icons` interface for the option prop
 import type { BoldIcon as GenericIcon } from '@kong/icons'
+import type { MarkdownItEnv } from '@mdit-vue/types'
 
 /** The current mode of the markdown component */
 export type MarkdownMode =
@@ -48,3 +49,12 @@ export interface TextAreaInputEvent {
 
 /** The color theme of the component */
 export type Theme = 'light' | 'dark'
+
+/** The markdown document frontmatter */
+export type Frontmatter = Pick<MarkdownItEnv, 'frontmatter'>
+
+/** The payload to emit for update:modelValue and save events */
+export interface EmitUpdatePayload {
+  content: string
+  frontmatter: Frontmatter | undefined
+}


### PR DESCRIPTION
# Summary

Process markdown frontmatter provided in the document via YAML.

Adds a new `@update:frontmatter` event that emits a payload of the frontmatter (or empty object) as the user updates their document.

Also updates the `@save` event payload to the following interface:

```typescript
interface EmitUpdatePayload {
  content: string
  frontmatter: Frontmatter | undefined
}
```

## Example

```md
---
title: About
layout: article
---

This is my document with frontmatter.
```