### PR TITLE
chore(stylelint): add rule empty line and opening brace space rules

### DIFF
--- a/.stylelintrc.mjs
+++ b/.stylelintrc.mjs
@@ -23,6 +23,8 @@ export default {
       },
     ],
     'custom-property-no-missing-var-function': true,
+    'rule-empty-line-before': ['always', { ignore: ['after-comment', 'first-nested'] }],
+    '@stylistic/block-opening-brace-space-before': 'always',
     // Disable the following rules
     'no-descending-specificity': null,
   },


### PR DESCRIPTION
# Summary

Add stylelint [`rule-empty-line-before`](https://stylelint.io/user-guide/rules/rule-empty-line-before/) rule to enforce empty line before CSS rules and [`block-opening-brace-space-before`](https://github.com/stylelint-stylistic/stylelint-stylistic/blob/main/lib/rules/block-opening-brace-space-before/README.md) rule to enforce space after opening brace in CSS rule

<!--
  Be sure your Pull Request includes:

  - JIRA ticket number in the title, and link in the summary
  - An accurate summary of what is being added/edited/removed
  - Tests (unit, component, regression)
  - Updated documentation and commented code
  - Link to Figma, if applicable
  - Conventional Commits
-->
