### PR TITLE
chore: add missing exports types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "typings": "dist/types",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/kong-markdown.es.js",
       "require": "./dist/kong-markdown.umd.js"
     },
@@ -194,5 +195,6 @@
       "jiraPrepend": "[",
       "jiraAppend": "]"
     }
-  }
+  },
+  "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6"
 }


### PR DESCRIPTION
# Summary

This pull request adds the missing `types` field in `exports` in `package.json`


## Before

<img width="1396" alt="Screenshot 2025-06-23 at 17 54 52" src="https://github.com/user-attachments/assets/4fe20f1c-4762-460f-b0c3-4bc17b2cab89" />

## After

<img width="1396" alt="Screenshot 2025-06-23 at 17 55 47" src="https://github.com/user-attachments/assets/5db29606-2d11-44f7-a846-9a9df32b378d" />
