### PR TITLE
ci: renovate bot name change [TDX-6752]

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   commitlint:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && github.actor != 'mend[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,7 +61,7 @@ jobs:
         - name: Publish Package Preview
           id: package-preview
           # Do not run for `alpha` or `beta` branches
-          if: github.event_name == 'pull_request' && (github.actor != 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package')) && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
+          if: github.event_name == 'pull_request' && (github.actor != 'renovate[bot]' || github.actor != 'mend[bot]' || contains(github.event.pull_request.labels.*.name, 'create preview package')) && !contains(github.head_ref || github.ref_name, 'alpha') && !contains(github.head_ref || github.ref_name, 'beta')
           run: |
             git config user.email "konnectx-engineers+kongponents-bot@konghq.com"
             git config user.name "Kong UI Bot"


### PR DESCRIPTION
# Description

Renovate is changing their Github app name https://github.com/renovatebot/renovate/discussions/37842

ticket: https://konghq.atlassian.net/browse/TDX-6752