### PR TITLE
fix(pnpm): enforce vulnerability protections

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# Require a package to be published at least 12 days (17280 minutes) before it can be installed
+minimumReleaseAge: 17280
+minimumReleaseAgeExclude:
+  - '@kong/*'
+  - '@kong-ui/*'
+  - '@kong-ui-public/*'
+# When set to no-downgrade, pnpm will fail if a package's trust level has decreased compared to previous releases
+trustPolicy: no-downgrade


### PR DESCRIPTION
# Summary

Harden our `pnpm` settings as part of `#_incident-721`

- `minimumReleaseAge: 17280` - includes transitive dependencies; however, does not cover anything already existing in the lockfile [Ref](https://pnpm.io/settings#minimumreleaseage)
- `trustPolicy: no-downgrade` - When set to `no-downgrade`, pnpm will fail if a package's trust level has decreased compared to previous releases.